### PR TITLE
docs(vortex): add module manuals and contracts

### DIFF
--- a/extensions/ryota-core.vortex-critic/assets/critic/README.md
+++ b/extensions/ryota-core.vortex-critic/assets/critic/README.md
@@ -1,0 +1,25 @@
+# Critic Hooks
+
+`assets/critic/` は read-only critic lane 用のスクリプト群です。
+
+## スクリプト
+
+| Script | Purpose |
+|---|---|
+| `deepseek-critic.py` | DeepSeek API を使う基本 critic hook |
+| `vortex-critic.py` | git diff とテスト証跡を見て、Completion Illusion を潰す VORTEX critic |
+
+## 使い方
+
+各スクリプトは stdin から JSON を受け取り、hook 互換の JSON を stdout に返します。
+
+```bash
+echo '{"prompt":"Review the diff"}' | python3 assets/critic/vortex-critic.py
+```
+
+## 付属設定
+
+- `deepseek-critic.config.json`
+- `vortex-critic.config.json`
+
+どちらも任意で、未配置ならスクリプト内のデフォルト設定を使います。

--- a/extensions/ryota-core.vortex-critic/assets/gemini/README.md
+++ b/extensions/ryota-core.vortex-critic/assets/gemini/README.md
@@ -1,0 +1,33 @@
+# Gemini Bridge and Memory Pipeline
+
+`assets/gemini/` は Gemini Code Assist の A2A ブリッジと、VORTEX の memory pipeline をまとめた領域です。
+
+## 主要スクリプト
+
+| Script | Purpose |
+|---|---|
+| `bootstrap_gemini_code_assist.sh` | Gemini ブリッジの起動補助 |
+| `gemini_a2a_bridge.py` | A2A HTTP ブリッジ本体 |
+| `memory_pipeline.py` | fleet_log → KI queue → promote → index → recall |
+| `fleet_bridge.py` | MCP / fleet 側の配線 |
+| `pcc_critic.py` | PCC 制約付き critic |
+| `pcc_critic_standalone.py` | 単体実行用 critic |
+| `titan_mcp_bridge.py` | Titan / remote MCP ブリッジ |
+
+## 付属資産
+
+- `newgate_profile.json`
+- `colab_ki_vectorizer.ipynb`
+
+## 典型フロー
+
+1. `gemini_a2a_bridge.py` が lane を受ける
+2. `memory_pipeline.py` が成功ログと KI 候補を蓄積する
+3. promote 後に `ConversationMemory.index_knowledge()` で索引化する
+4. recall を bridge prompt に注入する
+
+## 実行例
+
+```bash
+python3 assets/gemini/gemini_a2a_bridge.py --host 127.0.0.1 --port 8765
+```

--- a/extensions/ryota-core.vortex-critic/assets/pipeline/README.md
+++ b/extensions/ryota-core.vortex-critic/assets/pipeline/README.md
@@ -1,0 +1,20 @@
+# Pipeline 01
+
+`assets/pipeline/` は OSS packet 化と監査を回す Pipeline① の実装です。
+
+## 役割
+
+- repo を packet 化する
+- packet を Neural Packet ledger に保存する
+- CBF / n8n / mount 状態をまとめて status に出す
+- VORTEX サイドバーから状態を確認できるようにする
+- commit hook から queue へ積み、**issue-oriented follow-up** を非同期で回す
+
+## サブディレクトリ
+
+| Path | Purpose |
+|---|---|
+| `scripts/` | 起動・実行スクリプト |
+| `intelligence/` | packet / harvest / bridge モジュール |
+| `gate/` | CBF サーバー |
+| `integration/` | n8n workflow 定義 |

--- a/extensions/ryota-core.vortex-critic/assets/pipeline/gate/README.md
+++ b/extensions/ryota-core.vortex-critic/assets/pipeline/gate/README.md
@@ -1,0 +1,13 @@
+# Pipeline Gate
+
+`assets/pipeline/gate/` は Pipeline① の制御面です。
+
+| File | Purpose |
+|---|---|
+| `cbf.py` | Coordinate Build Framework (CBF) server |
+
+## 起動例
+
+```bash
+python3 assets/pipeline/gate/cbf.py --serve --host 127.0.0.1 --port 9801
+```

--- a/extensions/ryota-core.vortex-critic/assets/pipeline/intelligence/README.md
+++ b/extensions/ryota-core.vortex-critic/assets/pipeline/intelligence/README.md
@@ -1,0 +1,12 @@
+# Pipeline Intelligence
+
+`assets/pipeline/intelligence/` は packet 抽出と packet モデルの基盤です。
+
+## ファイル
+
+| File | Purpose |
+|---|---|
+| `harvest_js_packets.py` | JS/TS を Neural Packet に変換するハーベスター |
+| `eck_bridge.py` | ECK / drift 検証の bridge |
+| `neural_packet.py` | packet / ledger のデータモデル |
+

--- a/extensions/ryota-core.vortex-critic/assets/pipeline/scripts/README.md
+++ b/extensions/ryota-core.vortex-critic/assets/pipeline/scripts/README.md
@@ -1,0 +1,28 @@
+# Pipeline Scripts
+
+このディレクトリは Pipeline① の起動スクリプトです。
+
+| Script | Purpose |
+|---|---|
+| `bootstrap_pipeline_01.sh` | rclone mount / CBF / n8n をまとめて起動し、status JSON を書く |
+| `pipeline_01_runner.py` | packet harvest → issue packet 化 → レポート生成の runner |
+| `pipeline_01_enqueue_commit.py` | commit を queue に積み、必要なら worker を起動する |
+| `pipeline_01_commit_worker.py` | queue を drain し、commit snapshot を Pipeline① に流して issue 化する |
+| `install_pipeline_01_git_hook.sh` | `post-commit` hook を install し、commit → enqueue を自動化する |
+
+## 実行例
+
+```bash
+bash assets/pipeline/scripts/bootstrap_pipeline_01.sh
+python3 assets/pipeline/scripts/pipeline_01_runner.py
+python3 assets/pipeline/scripts/pipeline_01_enqueue_commit.py --repo-root /path/to/repo
+bash assets/pipeline/scripts/install_pipeline_01_git_hook.sh
+```
+
+## Commit-driven workflow
+
+1. `install_pipeline_01_git_hook.sh` で `post-commit` hook を入れる  
+2. commit 完了直後に `pipeline_01_enqueue_commit.py` が queue に投入  
+3. worker が必要なら自動起動  
+4. worker は `git archive <sha>` で **clean snapshot** を作り、その commit だけを Pipeline① に流す  
+5. 生成された issue candidate は 1 本の GitHub issue として publish できる  

--- a/extensions/ryota-core.vortex-critic/docs/README.md
+++ b/extensions/ryota-core.vortex-critic/docs/README.md
@@ -1,0 +1,74 @@
+# VORTEX Detailed Manual
+
+このディレクトリは、VORTEX を「単なる拡張機能」ではなく**複数モジュールの複合体**として定義するための説明書です。
+目的は、機能説明ではなく**責務境界・入出力・依存・失敗条件**を固定することです。
+
+## システム定義
+
+| Module | Source of truth | 受け取るもの | 返すもの / 出すもの | 永続データ |
+|---|---|---|---|---|
+| Extension Shell | `src/`, `package.json` | VS Code command, 設定, editor state | UI, output channel, subprocess 起動 | VS Code settings / snapshot files |
+| Critic | `assets/critic/` | prompt JSON, workspace path | hook payload (`additionalContext`) | なし |
+| Gemini Runtime | `assets/gemini/` | A2A request, MCP request, queue 操作 | lane response, queue result, recall block | fleet logs, KI queue, knowledge, brain |
+| Pipeline① | `assets/pipeline/` | repo path, state dir, provider settings | status JSON, issue packets, artifacts | packet DB, issue DB, status JSON |
+| External MCP | `../fusion-copilot/mcp-server/` | stdio MCP JSON-RPC | orchestration tool responses | 外部モジュール側で管理 |
+
+## モジュール境界ルール
+
+1. **Extension Shell は UI と起動制御だけを持つ。** provider routing や memory indexing の本体は入れない。  
+2. **Critic は read-only。** 実装やファイル変更を担当しない。次ターン改善のための文脈だけ返す。  
+3. **Gemini Runtime は運用レーン本体。** lane routing、fleet log、KI queue、recall 注入はここで扱う。  
+4. **Pipeline① は packet 化と監査のためのバッチ系。** 日常 UI 状態管理は持たない。  
+5. **External MCP は隣接モジュール。** VORTEX 本体 repo に同梱されていなくても、運用スタック上の依存として明示する。  
+
+## 典型データフロー
+
+```text
+VS Code command / UI
+  -> Extension Shell
+  -> (A) Critic hook
+  -> (B) Gemini A2A Bridge
+       -> local lanes / Fusion Gate
+       -> fleet_log
+       -> KI queue
+       -> knowledge + index
+       -> memory recall
+  -> (C) Pipeline①
+       -> packet DB
+       -> Claude/Gemini analysis
+       -> issue packet DB
+```
+
+## 読み分け
+
+| 欲しい情報 | 読むファイル |
+|---|---|
+| UI, command, settings の責務 | `docs/extension.md` |
+| read-only critic の厳密契約 | `docs/critic.md` |
+| A2A / queue / recall の厳密契約 | `docs/gemini.md` |
+| packetize / audit batch の厳密契約 | `docs/pipeline.md` |
+| 外部 MCP オーケストレーション | `docs/mcp-server.md` |
+
+## AI 向けに相性がいい docs 構成
+
+VORTEX のような複合システムでは、`docs/` 配下を次の粒度で切ると AI も人間も読みやすくなります。
+
+| Folder / File | 用途 |
+|---|---|
+| `docs/README.md` | 全体像と索引 |
+| `docs/extension.md` | UI / shell / commands |
+| `docs/critic.md` | read-only critic 契約 |
+| `docs/gemini.md` | runtime / memory / bridge 契約 |
+| `docs/pipeline.md` | batch / packet / audit 契約 |
+| `docs/mcp-server.md` | 外部 orchestration backend |
+| `docs/architecture/` | 将来、図や依存関係を増やす場所 |
+| `docs/contracts/` | JSON schema, endpoint, file format 契約 |
+| `docs/operations/` | 起動手順, 復旧手順, runbook |
+| `docs/decisions/` | 設計判断の記録 (ADR 系) |
+
+## 変更時の原則
+
+1. 新機能を足す前に、**どのモジュールの責務か**をここで決める。  
+2. データの保存先を増やす場合は、**どこが writer でどこが reader か**を書く。  
+3. 「失敗しても黙る」処理は、**どこで fail-soft / fail-closed にするか**を README に追記する。  
+4. 外部 repo や外部プロセスに依存する場合は、**相対パスと役割**を必ず明記する。  

--- a/extensions/ryota-core.vortex-critic/docs/contracts/README.md
+++ b/extensions/ryota-core.vortex-critic/docs/contracts/README.md
@@ -1,0 +1,19 @@
+# Contracts Index
+
+このディレクトリは、VORTEX の**機械可読に近い入出力契約**を置く場所です。
+モジュール説明よりも優先して参照される前提です。
+
+## Current contracts
+
+| Contract | File | Source of truth |
+|---|---|---|
+| A2A request / response | `docs/contracts/a2a-request-shape.md` | `assets/gemini/gemini_a2a_bridge.py` |
+| KI queue JSONL | `docs/contracts/ki-queue-schema.md` | `assets/gemini/memory_pipeline.py` |
+| Pipeline status JSON | `docs/contracts/status-json-schema.md` | `assets/pipeline/scripts/bootstrap_pipeline_01.sh`, `assets/pipeline/scripts/pipeline_01_runner.py` |
+| Critic hook I/O | `docs/contracts/critic-hook-io.md` | `assets/critic/deepseek-critic.py`, `assets/critic/vortex-critic.py` |
+
+## Rules
+
+1. 実装を変えたら、この folder も同じ commit で更新する。  
+2. 説明文より**field 名と fail behavior**を優先する。  
+3. 互換性のために残っている legacy key は、削除前にここへ明記する。  

--- a/extensions/ryota-core.vortex-critic/docs/contracts/a2a-request-shape.md
+++ b/extensions/ryota-core.vortex-critic/docs/contracts/a2a-request-shape.md
@@ -1,0 +1,155 @@
+# A2A Request Shape
+
+## Scope
+
+対象 surface:
+
+- `POST /v1/message:send`
+- `POST /v1/message:stream`
+- `POST /tasks`
+- `POST /executeCommand`
+- `GET /.well-known/agent-card.json`
+
+source of truth: `assets/gemini/gemini_a2a_bridge.py`
+
+## Request body for `/v1/message:send`
+
+### Accepted top-level keys
+
+| Key | Required | Type | Notes |
+|---|---|---|---|
+| `message` | preferred | object | 正式な入力 |
+| `request` | alias | object | `message` の alias として受理 |
+| `configuration` | no | object | `blocking` など |
+| `metadata` | no | object | top-level metadata |
+
+### Accepted message shape
+
+REST 経由では、bridge は次の2形式を受理します。
+
+#### Form A: explicit envelope
+
+```json
+{
+  "message": {
+    "kind": "message",
+    "messageId": "msg-1",
+    "contextId": "ctx-1",
+    "taskId": "",
+    "role": "user",
+    "parts": [
+      { "kind": "text", "text": "utility: summarize this" }
+    ],
+    "metadata": {}
+  }
+}
+```
+
+#### Form B: envelope-less REST form
+
+```json
+{
+  "message": {
+    "role": "user",
+    "parts": [
+      { "kind": "text", "text": "utility: summarize this" }
+    ]
+  },
+  "configuration": {
+    "blocking": true
+  }
+}
+```
+
+### Normalization rules
+
+`normalize_message()` は以下を保証します。
+
+1. `kind: "message"` があれば、その `parts` を使う  
+2. それが無い場合は `content` を見る  
+3. `content` が空なら `parts` を使う  
+4. `messageId`, `contextId`, `taskId` は snake_case alias も吸収する  
+5. `role` は内部 role に coercion される
+
+## Supported part shapes
+
+| Input shape | Normalized kind |
+|---|---|
+| `{ "kind": "text", "text": "..." }` | `text` |
+| `{ "text": "..." }` | `text` |
+| `{ "file": { ... } }` | `file` |
+| `{ "data": ... }` | `data` |
+
+## Response body for `/v1/message:send`
+
+```json
+{
+  "task": {
+    "id": "task-id",
+    "contextId": "context-id",
+    "status": {
+      "state": "TASK_STATE_COMPLETED",
+      "message": {
+        "messageId": "msg-id",
+        "contextId": "context-id",
+        "taskId": "task-id",
+        "role": "ROLE_AGENT",
+        "content": [
+          { "text": "..." }
+        ],
+        "metadata": {}
+      },
+      "timestamp": "2026-04-18T00:00:00+09:00"
+    },
+    "artifacts": [],
+    "history": [],
+    "metadata": {}
+  }
+}
+```
+
+## Streaming response for `/v1/message:stream`
+
+返るイベントは REST 変換された status update です。
+
+```json
+{
+  "taskId": "task-id",
+  "contextId": "context-id",
+  "status": {
+    "state": "TASK_STATE_WORKING",
+    "message": null,
+    "timestamp": "2026-04-18T00:00:00+09:00"
+  },
+  "final": false,
+  "metadata": {}
+}
+```
+
+## `POST /tasks`
+
+### Input
+
+```json
+{
+  "agentSettings": {
+    "route": "utility"
+  },
+  "contextId": "optional-context-id"
+}
+```
+
+### Output
+
+created task id だけを返す。
+
+## `POST /executeCommand`
+
+この endpoint は bridge command surface 用。  
+`command` と command-specific payload を受ける。
+
+## Compatibility notes
+
+- REST A2A client が `kind:"message"` を付けなくても text は落とさない  
+- route 強制は本文 prefix (`utility:`, `agent:`, `chat:`) でも行える  
+- multimodal backend が無い場合、image 系入力は fail-fast する  

--- a/extensions/ryota-core.vortex-critic/docs/contracts/critic-hook-io.md
+++ b/extensions/ryota-core.vortex-critic/docs/contracts/critic-hook-io.md
@@ -1,0 +1,105 @@
+# Critic Hook I/O
+
+## Scope
+
+source of truth:
+
+- `assets/critic/deepseek-critic.py`
+- `assets/critic/vortex-critic.py`
+
+両者とも **stdin JSON -> stdout hook payload** という同じ I/O 契約を持つ。
+
+## Input contract
+
+### Minimum input
+
+```json
+{
+  "prompt": "review this user request"
+}
+```
+
+### Common optional fields
+
+```json
+{
+  "prompt": "review this user request",
+  "activeFile": "/abs/path/file.ts",
+  "workspaceRoot": "/abs/path/repo"
+}
+```
+
+### VORTEX-specific optional evidence fields
+
+`vortex-critic.py` は次も受理する:
+
+```json
+{
+  "test_exit_code": 0,
+  "lint_exit_code": 0,
+  "scope_files": ["src/a.ts", "src/b.ts"]
+}
+```
+
+## Input parsing behavior
+
+`read_stdin_json()` の契約:
+
+1. stdin が空なら `{}`  
+2. stdin が object JSON ならそのまま  
+3. JSON parse に失敗したら `{ "prompt": raw_stdin }`
+
+つまり、**plain text だけ流しても prompt として扱う**。
+
+## Output contract
+
+### Success with additional context
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": "[VORTEX Critic]\n..."
+  }
+}
+```
+
+### No-op / fail-safe output
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit"
+  }
+}
+```
+
+## Invariants
+
+1. stdout は常に valid JSON を返す  
+2. `hookSpecificOutput.hookEventName` は常に `UserPromptSubmit`  
+3. `additionalContext` は**生成できたときだけ**入る  
+4. hook 失敗時でもプロセス全体を壊さない
+
+## Failure behavior
+
+| Condition | Behavior |
+|---|---|
+| config invalid | default config に戻る |
+| prompt missing | no-op payload を返す |
+| API key missing | stderr に書きつつ no-op payload を返す |
+| provider no response | no-op payload を返す |
+
+## deepseek vs vortex
+
+| Script | Extra behavior |
+|---|---|
+| `deepseek-critic.py` | prompt 중심の critic |
+| `vortex-critic.py` | `workspaceRoot` があれば git / test artifact を証跡として集める |
+
+## Non-goals
+
+- ファイル編集
+- テスト実行 orchestration
+- queue 更新
+- lane routing

--- a/extensions/ryota-core.vortex-critic/docs/contracts/ki-queue-schema.md
+++ b/extensions/ryota-core.vortex-critic/docs/contracts/ki-queue-schema.md
@@ -1,0 +1,154 @@
+# KI Queue Schema
+
+## Scope
+
+source of truth: `assets/gemini/memory_pipeline.py`
+
+queue file:
+
+```text
+~/.gemini/antigravity/ki-promotion-queue.jsonl
+```
+
+## Storage format
+
+- **JSONL**
+- 1行 = 1 queue entry
+- `write_queue()` は全件を書き直す
+
+## Queue entry schema
+
+`_make_queue_entry()` が生成する基本形:
+
+```json
+{
+  "id": "ki_abcd1234ef567890",
+  "status": "pending",
+  "created_at": "2026-04-18T00:00:00+09:00",
+  "updated_at": "2026-04-18T00:00:00+09:00",
+  "title": "Task title",
+  "summary": "Short result summary",
+  "task": "original task",
+  "result": "result body",
+  "cause": null,
+  "fix": null,
+  "tags": [],
+  "suggested_ki_name": "task_title",
+  "log_file": "/abs/path/fleet_20260418.jsonl",
+  "notebook_path": "/abs/path/colab_ki_vectorizer.ipynb"
+}
+```
+
+## Field meanings
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | string | `task + result` hash ベースの queue id |
+| `status` | string | `pending` or `promoted` |
+| `created_at` | string | queue 作成時刻 |
+| `updated_at` | string | 最終更新時刻 |
+| `title` | string | 表示用タイトル |
+| `summary` | string | 400文字以内の要約 |
+| `task` | string | 元タスク |
+| `result` | string | 元結果 |
+| `cause` | string/null | failure / recovery 文脈 |
+| `fix` | string/null | 修正内容 |
+| `tags` | array | 任意タグ |
+| `suggested_ki_name` | string | knowledge dir 候補 |
+| `log_file` | string | 元になった fleet log |
+| `notebook_path` | string | vectorizer notebook |
+
+## Promote-time mutation
+
+`handle_ki_queue_promote()` 成功後、entry には追加で以下が入る:
+
+```json
+{
+  "status": "promoted",
+  "promoted_at": "2026-04-18T00:10:00+09:00",
+  "knowledge_dir": "/abs/path/knowledge/my_ki",
+  "artifact_path": "/abs/path/knowledge/my_ki/artifacts/ki_xxx.md"
+}
+```
+
+## API contracts
+
+### `handle_ki_queue_list(arguments)`
+
+#### Input
+
+```json
+{
+  "status": "pending",
+  "limit": 20
+}
+```
+
+#### Output
+
+```json
+{
+  "status": "ok",
+  "queue_file": "/abs/path/ki-promotion-queue.jsonl",
+  "knowledge_dir": "/abs/path/knowledge",
+  "notebook_path": "/abs/path/notebook.ipynb",
+  "count": 3,
+  "entries": []
+}
+```
+
+### `handle_ki_queue_promote(arguments)`
+
+#### Required input
+
+```json
+{
+  "entry_id": "ki_abcd1234ef567890"
+}
+```
+
+#### Optional overrides
+
+- `ki_name`
+- `title`
+- `summary`
+- `artifact_name`
+- `content`
+
+#### Success output
+
+```json
+{
+  "status": "promoted",
+  "entry": {},
+  "knowledge_dir": "/abs/path/knowledge/my_ki",
+  "artifact_path": "/abs/path/knowledge/my_ki/artifacts/ki_xxx.md",
+  "notebook_path": "/abs/path/notebook.ipynb",
+  "indexed": true
+}
+```
+
+#### Failure output
+
+```json
+{ "error": "entry_id is required" }
+```
+
+or
+
+```json
+{ "error": "queue entry not found: ki_xxx" }
+```
+
+## Related knowledge directory shape
+
+promotion 先の `knowledge/<ki_name>/` には最低限:
+
+- `metadata.json`
+- `timestamps.json`
+- `artifacts/*.md`
+
+## Compatibility rule
+
+`entry_id` が唯一の必須 key。  
+`id` は **promote API 引数では無効** とみなす。  

--- a/extensions/ryota-core.vortex-critic/docs/contracts/status-json-schema.md
+++ b/extensions/ryota-core.vortex-critic/docs/contracts/status-json-schema.md
@@ -1,0 +1,158 @@
+# Pipeline Status JSON Schema
+
+## Scope
+
+source of truth:
+
+- `assets/pipeline/scripts/bootstrap_pipeline_01.sh`
+- `assets/pipeline/scripts/pipeline_01_runner.py`
+
+この schema は **1つの `status.json` が bootstrap 段階と runner 段階で拡張される** 前提です。
+
+## Bootstrap status
+
+`bootstrap_pipeline_01.sh` がまず書く形:
+
+```json
+{
+  "pipeline": "pipeline-01",
+  "stage": "bootstrapped",
+  "mounted": true,
+  "cbfHealthy": true,
+  "n8nReady": true,
+  "mountPath": "/abs/path",
+  "driveRemote": "gdrive",
+  "driveSubpath": "",
+  "rclonePath": "/opt/homebrew/bin/rclone",
+  "mountError": "",
+  "rcloneLog": "/abs/path/rclone_mount.log",
+  "workflowJson": "/abs/path/n8n-workflow-pipeline-01.json",
+  "bootstrapScript": "/abs/path/bootstrap_pipeline_01.sh"
+}
+```
+
+## Runner status
+
+`pipeline_01_runner.py` が同じ `status.json` を読み込み、以下の key を付け足しながら上書きします。
+
+### Common runner fields
+
+```json
+{
+  "pipeline": "pipeline-01",
+  "stage": "starting",
+  "started_at": "2026-04-18T00:00:00",
+  "repo_path": "/abs/path/repo",
+  "repo_name": "vscode-oss",
+  "mount_path": "/abs/path/mount",
+  "drive_remote": "gdrive",
+  "drive_subpath": "",
+  "mounted": false,
+  "cbfHealthy": true,
+  "n8nReady": true,
+  "artifacts": {}
+}
+```
+
+### Stage progression
+
+allowed stage values:
+
+- `bootstrapped`
+- `starting`
+- `packetizing`
+- `claude_analysis`
+- `gemini_issue_split`
+- `eck_persistence`
+- `completed`
+- `failed`
+
+## Stage-specific fields
+
+### After packetizing
+
+```json
+{
+  "packetizer": {
+    "exit_code": 0,
+    "stderr": ""
+  },
+  "packet_summary": {
+    "count": 123,
+    "sample_packets": []
+  },
+  "cbf": {
+    "packetized": {}
+  }
+}
+```
+
+### After Claude analysis
+
+```json
+{
+  "artifacts": {
+    "claude_analysis": "/abs/path/claude_analysis.json"
+  },
+  "cbf": {
+    "claude_analysis": {}
+  }
+}
+```
+
+### After Gemini issue split
+
+```json
+{
+  "artifacts": {
+    "gemini_issue_candidates": "/abs/path/gemini_issue_candidates.json"
+  },
+  "issue_count": 5,
+  "cbf": {
+    "gemini_issue_split": {}
+  }
+}
+```
+
+### After ECK persistence
+
+```json
+{
+  "artifacts": {
+    "issue_packets": "/abs/path/issue_packets.jsonl",
+    "eck_results": "/abs/path/eck_results.json",
+    "eck_archive_dir": "/abs/path/eck_archive_20260418T000000"
+  },
+  "eck": {},
+  "cbf": {
+    "eck_persistence": {}
+  },
+  "completed_at": "2026-04-18T00:10:00"
+}
+```
+
+### Failure shape
+
+```json
+{
+  "stage": "failed",
+  "error": "packetizer produced zero packets for vscode-oss; check harvest scope, mount state, or pass --allow-empty-packets to override",
+  "failed_at": "2026-04-18T00:02:00"
+}
+```
+
+## Fail-closed rule
+
+`packet_summary.count <= 0` かつ `--allow-empty-packets` 未指定なら、status は `failed` へ移行する。
+
+## Compatibility notes
+
+この file には camelCase と snake_case が混在する。
+
+| Legacy / bootstrap key | Runner key |
+|---|---|
+| `mountPath` | `mount_path` |
+| `driveRemote` | `drive_remote` |
+| `driveSubpath` | `drive_subpath` |
+
+reader 実装は両系統を受けられる前提で扱うこと。  

--- a/extensions/ryota-core.vortex-critic/docs/critic.md
+++ b/extensions/ryota-core.vortex-critic/docs/critic.md
@@ -1,0 +1,96 @@
+# Critic Module
+
+## 定義
+
+Critic モジュールは、VORTEX の**read-only 監査レーン**です。  
+ここは「実装」ではなく「次のターンを改善する追加文脈」を返す層です。
+
+## 管轄ファイル
+
+| File | Role |
+|---|---|
+| `assets/critic/deepseek-critic.py` | 基本 DeepSeek critic hook |
+| `assets/critic/vortex-critic.py` | evidence 優先の VORTEX critic hook |
+| `assets/critic/deepseek-critic.config.json` | DeepSeek critic runtime 設定 |
+| `assets/critic/vortex-critic.config.json` | VORTEX critic runtime 設定 |
+
+## 契約
+
+### 入力
+
+stdin から JSON を受け取ります。最低限必要なのは `prompt` です。
+
+```json
+{
+  "prompt": "review this change",
+  "activeFile": "/abs/path/file.ts",
+  "workspaceRoot": "/abs/path/repo"
+}
+```
+
+### 出力
+
+stdout には hook 互換 JSON を返します。  
+追加文脈が生成できたときだけ `hookSpecificOutput.additionalContext` が入ります。
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": "[VORTEX Critic]\\n..."
+  }
+}
+```
+
+## スクリプト差分
+
+| Script | 特徴 |
+|---|---|
+| `deepseek-critic.py` | prompt 中心。外部証跡の収集はしない |
+| `vortex-critic.py` | prompt + workspace evidence。git / test artifact を拾って Completion Illusion を検出する |
+
+## 設定解決順
+
+1. `*.config.json`
+2. `DEEPSEEK_API_KEY`
+3. macOS keychain (`security find-generic-password`)
+4. fallback service names
+
+設定が壊れていても、スクリプトは**デフォルト設定にフォールバック**します。
+
+## VORTEX critic の evidence ソース
+
+`vortex-critic.py` は `workspaceRoot` があれば次を収集します。
+
+- `git diff --stat HEAD`
+- `git diff --name-only HEAD`
+- `git diff --name-only --cached`
+- `git log -1 --oneline`
+- 代表的な test artifact の存在
+
+ここでの原則は、**自然言語の完了報告より証跡を優先する**ことです。
+
+## 失敗時の契約
+
+| 事象 | 振る舞い |
+|---|---|
+| `prompt` が無い | `emit(None)` で空 hook payload を返す |
+| API key が無い | stderr に出しつつ、空 hook payload を返す |
+| provider から応答が無い | 空 hook payload を返す |
+| config JSON が壊れている | デフォルト設定に戻る |
+
+つまり、**hook を壊さない**のが最優先契約です。
+
+## 非責務
+
+- ファイル編集
+- テスト実行の orchestration
+- queue 生成
+- KI 永続化
+- lane routing
+
+## 改修ルール
+
+1. Critic の出力は**追加文脈**であって、実行命令ではない。  
+2. `vortex-critic.py` に証跡を足す場合は、**workspace が無くても壊れない**ことを維持する。  
+3. completion illusion 検出ロジックは強化してよいが、**write side effect** は持ち込まない。  

--- a/extensions/ryota-core.vortex-critic/docs/gemini.md
+++ b/extensions/ryota-core.vortex-critic/docs/gemini.md
@@ -1,0 +1,135 @@
+# Gemini Bridge Module
+
+## 定義
+
+Gemini モジュールは、VORTEX の**実働レーン本体**です。  
+UI から来た要求を A2A / MCP / memory pipeline に流し、最終的に local lane や Fusion Gate へ渡します。
+
+## 管轄ファイル
+
+| File | Role |
+|---|---|
+| `assets/gemini/gemini_a2a_bridge.py` | A2A HTTP bridge。本番の入口 |
+| `assets/gemini/memory_pipeline.py` | fleet log / KI queue / promote / index / recall |
+| `assets/gemini/fleet_bridge.py` | GPT-5 mini / Copilot CLI 系向け MCP stdio bridge |
+| `assets/gemini/titan_mcp_bridge.py` | MBA から Mac Studio の HTTP tool surface へ中継 |
+| `assets/gemini/pcc_critic.py` | Gemini CLI を使う PCC critic |
+| `assets/gemini/pcc_critic_standalone.py` | 単体 critic 実行 |
+| `assets/gemini/bootstrap_gemini_code_assist.sh` | bridge 起動補助 |
+| `assets/gemini/newgate_profile.json` | Newgate profile |
+
+## A2A bridge の厳密契約
+
+### HTTP surface
+
+`gemini_a2a_bridge.py` は少なくとも次を提供します。
+
+| Endpoint | Role |
+|---|---|
+| `/.well-known/agent-card.json` | agent card |
+| `/v1/card` | card alias |
+| `/v1/message:send` | 単発メッセージ処理 |
+| `/v1/message:stream` | SSE stream |
+| `/tasks` | task 作成 |
+| `/executeCommand` | command 実行 |
+
+### ルーティング
+
+| Route | Backend |
+|---|---|
+| `conversation` | `8103` |
+| `agent` | `8102` |
+| `utility` | `8101` |
+
+prefix / alias で route を強制できます。  
+また `normalize_message()` は REST client 由来の `content` 形式と `parts` 形式の両方を正規化対象にします。
+
+### recall 注入
+
+`_build_openai_messages()` で最新 user turn に対して `try_recall()` を呼び、  
+`[Memory Recall]` を system prompt に差し込みます。
+
+この recall は**best-effort**です。失敗しても lane 実行自体は止めません。
+
+### 起動モード
+
+`bootstrap_gemini_code_assist.sh` は次の 2 モードを持ちます。
+
+- `tmux` — 既定。singleton session で bridge を常駐させる
+- `subprocess` — fallback / 単発起動
+
+`GEMINI_A2A_LAUNCHER=tmux` と `GEMINI_A2A_TMUX_SESSION=<name>` を使うと、**IDE window ごとの多重起動を避けやすい**です。
+
+## Memory pipeline の厳密契約
+
+### 永続データ
+
+| Path | Role |
+|---|---|
+| `~/.gemini/antigravity/fleet-logs/` | fleet JSONL |
+| `~/.gemini/antigravity/ki-promotion-queue.jsonl` | 昇格待ち queue |
+| `~/.gemini/antigravity/knowledge/` | promoted KI |
+| `~/.gemini/antigravity/brain/` | raw memory |
+
+### 公開 API
+
+| Function | Contract |
+|---|---|
+| `emit_fleet_log()` | fire-and-forget で fleet log を書く |
+| `handle_fleet_log()` | MCP 向け log handler |
+| `handle_ki_queue_list()` | queue 一覧 |
+| `handle_ki_queue_promote()` | `entry_id` を要求し、knowledge 化 + auto-index |
+| `try_recall()` | recall block を返す。失敗時は `""` |
+
+### promote 結果
+
+promotion は `knowledge/<ki_name>/` に以下を作ります。
+
+- `metadata.json`
+- `timestamps.json`
+- `artifacts/*.md`
+
+さらに `_try_index_knowledge()` が成功すれば、その場で index 更新まで進みます。
+
+## Fleet bridge / Titan bridge
+
+### `fleet_bridge.py`
+
+- stdio JSON-RPC で受ける
+- `TOOLS` でツール一覧を返す
+- memory pipeline と Fusion Gate relay の間をつなぐ
+
+### `titan_mcp_bridge.py`
+
+- MBA 側 stdio MCP を Mac Studio HTTP API に流す
+- remote tool surface をローカル MCP 風に見せる
+
+## 依存
+
+| Dependency | 用途 |
+|---|---|
+| local OpenAI-compatible endpoints | conversation / agent / utility lane |
+| Fusion Gate | provider invoke / cache / protocol injection |
+| `ConversationMemory` | recall / knowledge index |
+| Gemini CLI | PCC critic |
+
+## 失敗時の契約
+
+| 事象 | 振る舞い |
+|---|---|
+| recall 失敗 | prompt から recall を抜いて継続 |
+| image / multimodal 非対応 | fail-fast |
+| `handle_ki_queue_promote()` に `entry_id` が無い | `{"error": "entry_id is required"}` |
+| Fusion Gate / Titan 不達 | bridge 側で error payload を返す |
+
+## 非責務
+
+- VS Code UI
+- status bar / sidebar 描画
+- packet harvest
+
+## 改修ルール
+
+1. lane routing を変えるときは、**A2A surface と prefix 強制の両方**を見る。  
+2. memory pipeline の fail-soft は、**運用継続のための fail-soft**だけに使う。  
+3. queue schema を変えるときは、writer / reader / promote 処理を同時に更新する。  

--- a/extensions/ryota-core.vortex-critic/docs/mcp-server.md
+++ b/extensions/ryota-core.vortex-critic/docs/mcp-server.md
@@ -1,0 +1,61 @@
+# MCP Server Module
+
+## 定義
+
+このモジュールは **VORTEX nested repo の内側には存在しません**。  
+実体は隣接パスの `../fusion-copilot/mcp-server/` にある、**外部 orchestration モジュール**です。
+
+VORTEX の説明書に含める理由は、運用上このサーバーが **Qwen / Gemini / Jules / n8n orchestration の公開面**だからです。
+
+## 実体パス
+
+```text
+/Users/ryyota/vscode-oss/extensions/fusion-copilot/mcp-server
+```
+
+## package 契約
+
+- package 名: `fusion-orchestrator-v2`
+- transport: stdio MCP
+- runtime: Node.js + TypeScript
+
+## 責務
+
+1. Qwen chat / code / batch を MCP tool として公開する  
+2. Jules / Gemini CLI / n8n trigger を外部クライアントから呼べるようにする  
+3. orchestration を VS Code 拡張本体から分離する  
+
+## ツール群
+
+README と `package.json` から見える主な公開群:
+
+- `qwen_chat`
+- `qwen_code`
+- `qwen_batch`
+- `jules_*`
+- `gemini_deepthink`
+- `gemini_deepsearch`
+- `n8n_trigger`
+- `qwen_health`
+- `orchestrate`
+
+## 依存
+
+| Dependency | Purpose |
+|---|---|
+| `jules` CLI | 非同期 coding session |
+| `gemini` CLI | DEEPTHINK / DEEPSEARCH |
+| `gh` CLI | GitHub 連携 |
+| `n8n` | workflow trigger |
+
+## VORTEX 本体との境界
+
+- VORTEX nested repo は**このサーバーの UI や説明を持てる**
+- ただし **実装 source of truth は external module 側**
+- VORTEX から見れば「隣の orchestration backend」
+
+## 改修ルール
+
+1. このモジュールの仕様変更は、VORTEX 本体 README でも**external dependency 変更**として追記する。  
+2. nested repo 側で存在しないパスを、同梱物のように書かない。  
+3. MCP ツール増減時は、**VORTEX がどこまで直接依存しているか**も明記する。  

--- a/extensions/ryota-core.vortex-critic/docs/pipeline.md
+++ b/extensions/ryota-core.vortex-critic/docs/pipeline.md
@@ -1,0 +1,150 @@
+# Pipeline① Module
+
+## 定義
+
+Pipeline① は、OSS repo を**packet 化して監査用 artifacts に落とすバッチ系モジュール**です。  
+常時対話用ではなく、状態を `status.json` に書き出しながら進む運用パイプラインです。
+
+## 管轄ファイル
+
+| File | Role |
+|---|---|
+| `assets/pipeline/scripts/bootstrap_pipeline_01.sh` | mount / CBF / n8n の bootstrap |
+| `assets/pipeline/scripts/pipeline_01_runner.py` | packetize -> analysis -> issue packet persist |
+| `assets/pipeline/scripts/pipeline_01_enqueue_commit.py` | commit を queue へ enqueue |
+| `assets/pipeline/scripts/pipeline_01_commit_worker.py` | queue を drain し、commit snapshot を処理 |
+| `assets/pipeline/scripts/install_pipeline_01_git_hook.sh` | `post-commit` hook installer |
+| `assets/pipeline/intelligence/harvest_js_packets.py` | repo を Neural Packet 化 |
+| `assets/pipeline/intelligence/neural_packet.py` | packet / ledger モデル |
+| `assets/pipeline/intelligence/eck_bridge.py` | ECK bridge |
+| `assets/pipeline/gate/cbf.py` | CBF server |
+
+## bootstrap の厳密契約
+
+### 入力
+
+主に環境変数で受けます。
+
+| Variable | Purpose |
+|---|---|
+| `PIPELINE_01_STATE_DIR` | state 出力先 |
+| `PIPELINE_01_STATUS_FILE` | status JSON path |
+| `PIPELINE_01_MOUNT_PATH` | rclone mount 先 |
+| `PIPELINE_01_RCLONE_REMOTE` / `PIPELINE_01_RCLONE_SUBPATH` | drive mount 元 |
+| `PIPELINE_01_N8N_COMPOSE` | compose file |
+| `PIPELINE_01_WORKFLOW_JSON` | workflow 定義 |
+| `PIPELINE_01_CBF_LAUNCHER` | `tmux` / `subprocess` |
+| `PIPELINE_01_CBF_TMUX_SESSION` | CBF の tmux session 名 |
+| `PIPELINE_01_CONTAINER_RUNTIME` | `auto` / `orbstack` / `docker` |
+
+### 出力
+
+`status.json` に最低限次を書きます。
+
+- `pipeline`
+- `stage`
+- `mounted`
+- `cbfHealthy`
+- `n8nReady`
+- `containerRuntime`
+- `dockerContext`
+- `cbfLauncher`
+- `mountError`
+- `rcloneLog`
+
+### 失敗コード
+
+mount の代表的な失敗値:
+
+- `rclone_not_found`
+- `mount_not_visible`
+
+## runner の厳密契約
+
+### CLI 引数
+
+`pipeline_01_runner.py` は次を受けます。
+
+- `--repo-path`
+- `--repo-name`
+- `--state-dir`
+- `--packet-db`
+- `--issue-db`
+- `--status-path`
+- `--mount-path`
+- `--drive-remote`
+- `--drive-subpath`
+- `--claude-provider`
+- `--gemini-provider`
+- `--pcc`
+- `--allow-empty-packets`
+
+### 実行ステージ
+
+runner は `status["stage"]` を進めながら動きます。
+
+1. `starting`
+2. `packetizing`
+3. `claude_analysis`
+4. `gemini_issue_split`
+5. `eck_persistence`
+6. `completed`
+7. `failed`
+
+### 永続成果物
+
+| Artifact | 内容 |
+|---|---|
+| `status.json` | 現在状態 |
+| `packet_db` | harvested packets |
+| `issue_db` | issue packets |
+| `claude_analysis.json` | Claude 側分析 |
+| `gemini_issue_candidates.json` | Gemini 側 issue candidate |
+| `issue_packets.jsonl` | issue packet export |
+
+### commit queue workflow
+
+Pipeline① には **commit-driven queue** を追加できます。
+
+1. `install_pipeline_01_git_hook.sh` を一度実行する  
+2. 各 commit で `post-commit` hook が `pipeline_01_enqueue_commit.py` を叩く  
+3. enqueue script は queue に payload を積み、必要なら worker を起動する  
+4. worker は `git archive <sha>` で **dirty worktree から切り離した snapshot** を作る  
+5. snapshot に対して `pipeline_01_runner.py` を流し、issue candidate を作る  
+6. 設定が揃っていれば、その結果を GitHub issue として publish する
+
+この設計の意味は、**commit 後に人間や agent が待ちぼうけしなくていい**ことです。  
+agent の役割は「pipeline に投げる」までで、重い処理は queue worker が引き受けます。
+
+## fail-closed 契約
+
+`packet_summary.count <= 0` のとき、`--allow-empty-packets` が無ければ**失敗**にします。  
+これは「ゼロ件でも成功扱いにしてしまう」挙動を防ぐためです。
+
+## 依存
+
+| Dependency | 用途 |
+|---|---|
+| `harvest_js_packets.py` | repo packetization |
+| Fusion Gate | Claude / Gemini provider invoke |
+| CBF server | step 記録 |
+| SQLite | packet / issue ledger |
+| rclone / docker compose | bootstrap 周辺 |
+
+### tmux / OrbStack 運用
+
+- CBF サーバーは既定で `tmux` singleton にできます。
+- `PIPELINE_01_CONTAINER_RUNTIME=auto` は `docker context show` を見て、`orbstack` context なら OrbStack 実験モードとして status に記録します。
+- n8n 自体の起動コマンドは引き続き `docker compose` ですが、OrbStack を docker backend にしていればそのまま OrbStack 上で動きます。
+
+## 非責務
+
+- VS Code の UI 表示
+- conversation lane routing
+- KI queue 運用
+
+## 改修ルール
+
+1. stage 名を変えるなら、**status reader 側も必ず合わせる**。  
+2. 失敗時に `status.json` を書かずに落ちる挙動は作らない。  
+3. packetizer を変えるときは、**ゼロ packet fail-closed** を維持する。  


### PR DESCRIPTION
## Summary
- add module manuals for critic, gemini, pipeline, and MCP boundaries
- add contracts for A2A shape, KI queue, critic hook I/O, and pipeline status
- make the fork easier to read as an intentional VORTEX workspace instead of an opaque patch pile
