### PR TITLE
feat(skill): add OrbStack Gemini semantic tests

### DIFF
--- a/.github/skills/orbstack-gemini-semantic-tests/LATEST_REPORT.md
+++ b/.github/skills/orbstack-gemini-semantic-tests/LATEST_REPORT.md
@@ -1,0 +1,177 @@
+# OrbStack Gemini Semantic Experiment
+
+- timestamp_utc: `2026-04-18T23:21:45Z`
+- hypothesis: Validate the latest multi-layer semantic workflow across OrbStack runtime, VORTEX control-plane state, and commit-driven pipeline follow-up.
+- repo_root: `/Users/ryyota/vscode-oss`
+- lab_root: `/Users/ryyota/scratch/warp-acp-cli-lab`
+
+## Runtime evidence
+
+```text
+timestamp_utc: 2026-04-18T23:21:45Z
+repo_root: /Users/ryyota/vscode-oss
+lab_root: /Users/ryyota/scratch/warp-acp-cli-lab
+repo_head: 4aaffc4bb9c2c3f824749a90c263100f48d27381
+repo_branch: main
+
+[docker context]
+NAME         DESCRIPTION                               DOCKER ENDPOINT                                  ERROR
+default      Current DOCKER_HOST based configuration   unix:///var/run/docker.sock                      
+orbstack *   OrbStack                                  unix:///Users/ryyota/.orbstack/run/docker.sock   
+
+[orb list]
+antigravity-linux  running  ubuntu  noble     arm64  6.1 GB   192.168.139.45
+pe-gemini-lab      running  ubuntu  questing  arm64  1.1 GB   192.168.139.15
+ubuntu             running  ubuntu  noble     arm64  10.9 GB  192.168.139.189
+
+[relevant containers]
+warp-acp-cli-lab	Up 5 hours
+pipeline-01-n8n	Up 6 hours
+ryota-temporal	Up 6 hours
+ryota-temporal-db	Up 6 hours (healthy)
+ryota-temporal-ui	Up 6 hours
+ryota-qdrant	Up 6 hours
+ryota-redis	Up 6 hours
+
+[pipeline status]
+{
+  "pipeline": "pipeline-01",
+  "stage": "bootstrapped",
+  "mounted": true,
+  "cbfHealthy": true,
+  "n8nReady": true,
+  "containerRuntime": "orbstack",
+  "dockerContext": "orbstack",
+  "containerRuntimeNote": "",
+  "cbfLauncher": "tmux",
+  "cbfTmuxSession": "vortex-pipeline-cbf",
+  "mountMode": "nfs",
+  "mountPath": "/Users/ryyota/GoogleDriveCache/oss",
+  "driveRemote": "gdrive",
+  "driveSubpath": "",
+  "rclonePath": "/Users/ryyota/.local/bin/rclone",
+  "mountError": "",
+  "rcloneLog": "/Users/ryyota/vscode-oss/.build/ryota/pipeline_01/rclone_nfs.log",
+  "rcloneMountLog": "/Users/ryyota/vscode-oss/.build/ryota/pipeline_01/rclone_mount.log",
+  "rcloneNfsLog": "/Users/ryyota/vscode-oss/.build/ryota/pipeline_01/rclone_nfs.log",
+  "rcloneNfsPidFile": "/Users/ryyota/vscode-oss/.build/ryota/pipeline_01/rclone_nfs.pid",
+  "rcloneNfsAddr": "127.0.0.1",
+  "rcloneNfsPort": "39091",
+  "n8nCompose": "/Users/ryyota/vscode-oss/extensions/ryota-core.vortex-critic/assets/pipeline/integration/n8n-compose.pipeline_01.yml",
+  "workflowJson": "/Users/ryyota/vscode-oss/extensions/ryota-core.vortex-critic/assets/pipeline/integration/n8n-workflow-pipeline-01.json",
+  "bootstrapScript": "/Users/ryyota/vscode-oss/extensions/ryota-core.vortex-critic/assets/pipeline/scripts/bootstrap_pipeline_01.sh"
+}
+
+[pipeline queue status]
+{
+  "queueFile": "/Users/ryyota/vscode-oss/extensions/ryota-core.vortex-critic/assets/pipeline/data/pipeline_01/commit_queue.jsonl",
+  "updatedAt": "2026-04-18T23:21:38.465659+00:00",
+  "counts": {
+    "pending": 0,
+    "in_progress": 0,
+    "completed": 2,
+    "failed": 0
+  },
+  "activeEntry": null,
+  "latestCompleted": {
+    "id": "commit-4aaffc4bb9c2c3f824749a90c263100f48d27381",
+    "status": "completed",
+    "sha": "4aaffc4bb9c2c3f824749a90c263100f48d27381",
+    "repo_root": "/Users/ryyota/vscode-oss",
+    "repo_name": "vscode-oss",
+    "branch": "main",
+    "subject": "docs(vortex): add module manuals and contracts",
+    "body": "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>",
+    "author": "tanakaryotadayo-wq <tanakaryotadayo-wq@users.noreply.github.com>",
+    "committed_at": "2026-04-19T06:06:04+09:00",
+    "changed_files": [
+      "extensions/ryota-core.vortex-critic/assets/critic/README.md",
+      "extensions/ryota-core.vortex-critic/assets/gemini/README.md",
+      "extensions/ryota-core.vortex-critic/assets/pipeline/README.md",
+      "extensions/ryota-core.vortex-critic/assets/pipeline/gate/README.md",
+      "extensions/ryota-core.vortex-critic/assets/pipeline/intelligence/README.md",
+      "extensions/ryota-core.vortex-critic/assets/pipeline/scripts/README.md",
+      "extensions/ryota-core.vortex-critic/docs/README.md",
+      "extensions/ryota-core.vortex-critic/docs/contracts/README.md",
+      "extensions/ryota-core.vortex-critic/docs/contracts/a2a-request-shape.md",
+      "extensions/ryota-core.vortex-critic/docs/contracts/critic-hook-io.md",
+      "extensions/ryota-core.vortex-critic/docs/contracts/ki-queue-schema.md",
+      "extensions/ryota-core.vortex-critic/docs/contracts/status-json-schema.md",
+      "extensions/ryota-core.vortex-critic/docs/critic.md",
+      "extensions/ryota-core.vortex-critic/docs/gemini.md",
+      "extensions/ryota-core.vortex-critic/docs/mcp-server.md",
+      "extensions/ryota-core.vortex-critic/docs/pipeline.md"
+    ],
+    "diff_stat": ".../assets/critic/README.md                        |  25 ++++\n .../assets/gemini/README.md                        |  33 +++++\n .../assets/pipeline/README.md                      |  20 +++\n .../assets/pipeline/gate/README.md                 |  13 ++\n .../assets/pipeline/intelligence/README.md         |  12 ++\n .../assets/pipeline/scripts/README.md              |  28 ++++\n extensions/ryota-core.vortex-critic/docs/README.md |  74 ++++++++++\n .../docs/contracts/README.md                       |  19 +++\n .../docs/contracts/a2a-request-shape.md            | 155 ++++++++++++++++++++\n .../docs/contracts/critic-hook-io.md               | 105 ++++++++++++++\n .../docs/contracts/ki-queue-schema.md              | 154 ++++++++++++++++++++\n .../docs/contracts/status-json-schema.md           | 158 +++++++++++++++++++++\n extensions/ryota-core.vortex-critic/docs/critic.md |  96 +++++++++++++\n extensions/ryota-core.vortex-critic/docs/gemini.md | 135 ++++++++++++++++++\n .../ryota-core.vortex-critic/docs/mcp-server.md    |  61 ++++++++\n .../ryota-core.vortex-critic/docs/pipeline.md      | 150 +++++++++++++++++++\n 16 files changed, 1238 insertions(+)",
+    "publish_issue": true,
+    "target_repo": "tanakaryotadayo-wq/warp-acp-cli-lab",
+    "enqueued_at": "2026-04-18T21:06:04.411622+00:00",
+    "updated_at": "2026-04-18T21:08:05.350096+00:00",
+    "started_at": "2026-04-18T21:06:05.550342+00:00",
+    "completed_at": "2026-04-18T21:08:05.349805+00:00",
+    "result": {
+      "run_dir": "/Users/ryyota/vscode-oss/extensions/ryota-core.vortex-critic/assets/pipeline/data/pipeline_01/commit_runs/4aaffc4b-1776546365",
+      "snapshot_dir": "/Users/ryyota/vscode-oss/extensions/ryota-core.vortex-critic/assets/pipeline/data/pipeline_01/commit_runs/4aaffc4b-1776546365/snapshot",
+      "bootstrap_log": "/Users/ryyota/vscode-oss/extensions/ryota-core.vortex-critic/assets/pipeline/data/pipeline_01/commit_runs/4aaffc4b-1776546365/bootstrap.log",
+      "context_json": "/Users/ryyota/vscode-oss/extensions/ryota-core.vortex-critic/assets/pipeline/data/pipeline_01/commit_runs/4aaffc4b-1776546365/commit_context.json",
+      "context_md": "/Users/ryyota/vscode-oss/extensions/ryota-core.vortex-critic/assets/pipeline/data/pipeline_01/commit_runs/4aaffc4b-1776546365/commit_context.md",
+      "status_path": "/Users/ryyota/vscode-oss/extensions/ryota-core.vortex-critic/assets/pipeline/data/pipeline_01/commit_runs/4aaffc4b-1776546365/status.json",
+      "runner_exit_code": 0,
+      "issue_publish": {
+        "published": true,
+        "issue_url": "https://github.com/tanakaryotadayo-wq/warp-acp-cli-lab/issues/3",
+        "candidate_count": 5,
+        "issue_body_path": "/Users/ryyota/vscode-oss/extensions/ryota-core.vortex-critic/assets/pipeline/data/pipeline_01/commit_runs/4aaffc4b-1776546365/github_issue.md"
+      }
+    }
+  },
+  "latestFailed": null
+}
+
+[warp lab files]
+services:
+  warp-acp-cli-lab:
+    build:
+      context: .
+    container_name: warp-acp-cli-lab
+    stdin_open: true
+    tty: true
+    environment:
+      WARP_API_KEY: ${WARP_API_KEY:-}
+      ACP_SERVER_URL: ${ACP_SERVER_URL:-http://host.docker.internal:3100}
+      FUSION_GATE_URL: ${FUSION_GATE_URL:-http://host.docker.internal:9800}
+      MCP_ROOT: ${MCP_ROOT:-/workspace/fusion-orchestrator-v2}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./warp-import:/opt/warp-import:ro
+      - ./workspace:/workspace/lab
+      - /Users/ryyota/vscode-copilot-chat/fusion-copilot/mcp-server:/workspace/fusion-orchestrator-v2
+    working_dir: /workspace/lab
+    command: ["/bin/bash"]
+
+[gemini cli]
+gemini_bin: /opt/homebrew/bin/gemini
+0.38.2
+```
+
+## Gemini read-only result
+
+### Verdict
+The test is highly successful and meaningful. It validates an end-to-end integration across containerized services, file mounts, task queuing, and AI-driven codebase analysis, culminating in a real, deeply contextual GitHub issue being published. It is not just a smoke test; it proves the full data flow from git commit to intelligent agent output works.
+
+### Runtime Layer
+All core infrastructure components (`orbstack`, `n8n`, `ryota-temporal`, `ryota-qdrant`, `ryota-redis`, and `warp-acp-cli-lab`) are stable and have been running continuously for 5-6 hours. The NFS mount via `rclone` is properly established (`mountMode: nfs` at `127.0.0.1:39091`), allowing seamless file sharing between the macOS host and the Docker environment.
+
+### Semantic Layer
+The semantic extraction and analysis phase functioned correctly. Even though the triggering commit (`4aaffc4b...`) consisted entirely of documentation additions (`docs(vortex)`), the semantic engine successfully analyzed the broader repository context and generated 5 high-quality issue candidates (e.g., identifying architectural risks in `.eslint-plugin-local`). This proves the critic layer has deep, actionable codebase awareness beyond the immediate diff.
+
+### Commit/Pipeline Layer
+The pipeline queue (`commit_queue.jsonl`) successfully consumed and processed the target commit. The workflow accurately navigated the entire lifecycle: bootstrapping, snapshot generation, context extraction (`commit_context.json`/`.md`), and runner execution (exit code `0`). It successfully formatted and published the final output to the target lab repository's issue tracker.
+
+### Best Next Test
+Trigger a commit that introduces a deliberate logic flaw, security vulnerability, or architectural violation (rather than a documentation update). This will verify if the semantic critic can accurately detect, isolate, and prioritize code-level regressions within an actual diff. Following that, use the Warp ACP CLI inside the lab container to autonomously read and resolve the newly generated issue.
+
+## Commit note
+
+- This report is intended to be committed so the commit-driven pipeline can pick up the latest OrbStack experiment.

--- a/.github/skills/orbstack-gemini-semantic-tests/SKILL.md
+++ b/.github/skills/orbstack-gemini-semantic-tests/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: orbstack-gemini-semantic-tests
+description: Use when the user wants meaningful OrbStack/Gemini CLI experiments instead of shallow smoke checks. This skill defines a multi-layer semantic test workflow: inspect OrbStack runtime, inspect pipeline/control-plane state, run Gemini CLI in read-only mode against that evidence, write a concise experiment report, then commit the report so the commit-driven pipeline can pick it up.
+---
+
+# OrbStack Gemini Semantic Tests
+
+Use this skill when the user wants **meaningful tests**, not just "does the container start?" checks.
+
+## What counts as meaningful
+
+A good test must touch at least **three layers**:
+
+1. **Runtime layer** — OrbStack, docker context, running lab/container state
+2. **Semantic/control layer** — Gemini CLI read-only analysis over real workspace + lab context
+3. **Commit/pipeline layer** — write a report and commit it so the commit-driven pipeline can react
+
+Do **not** stop at health checks, version output, or "it booted".
+
+## Workflow
+
+1. **Define one hypothesis.** Example: "The current OrbStack-backed workflow is ready for repeated Gemini CLI semantic investigations without depending on manual FUSE setup."
+2. **Collect real evidence.** Check OrbStack/docker state, pipeline status, active mount mode, lab container status, and relevant repo paths.
+3. **Run Gemini CLI in read-only mode.** Use `--approval-mode plan` and include both the repo and OrbStack lab directories.
+4. **Write a concise report.** The report should say what was tested, what evidence exists, what Gemini concluded, and what next test is most valuable.
+5. **Commit the report.** This is part of the workflow, not an optional extra.
+
+## Standard command
+
+```bash
+bash .github/skills/orbstack-gemini-semantic-tests/scripts/run-orbstack-semantic-experiment.sh
+```
+
+## Output contract
+
+The generated report should include:
+
+- hypothesis
+- runtime evidence
+- semantic analysis result
+- verdict
+- next meaningful test
+
+Default output path:
+
+```text
+.github/skills/orbstack-gemini-semantic-tests/LATEST_REPORT.md
+```
+
+## Rules
+
+1. Prefer **real evidence** over narrative.
+2. Keep Gemini in **read-only / plan** mode for experiments.
+3. Do not include secrets, env dumps, or API keys in the report.
+4. After generating the report, **commit and push** it on a dedicated branch.

--- a/.github/skills/orbstack-gemini-semantic-tests/scripts/run-orbstack-semantic-experiment.sh
+++ b/.github/skills/orbstack-gemini-semantic-tests/scripts/run-orbstack-semantic-experiment.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SKILL_DIR/../../.." && pwd)}"
+LAB_ROOT="${LAB_ROOT:-/Users/ryyota/scratch/warp-acp-cli-lab}"
+OUTPUT_FILE="${1:-$SKILL_DIR/LATEST_REPORT.md}"
+HYPOTHESIS="${EXPERIMENT_HYPOTHESIS:-Validate the latest multi-layer semantic workflow across OrbStack runtime, VORTEX control-plane state, and commit-driven pipeline follow-up.}"
+GEMINI_BIN="${GEMINI_BIN:-$(command -v gemini || true)}"
+TIMESTAMP_UTC="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+TMP_DIR="$(mktemp -d)"
+EVIDENCE_FILE="$TMP_DIR/evidence.txt"
+GEMINI_STDOUT="$TMP_DIR/gemini.stdout"
+GEMINI_STDERR="$TMP_DIR/gemini.stderr"
+
+cleanup() {
+	rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+{
+	echo "timestamp_utc: $TIMESTAMP_UTC"
+	echo "repo_root: $REPO_ROOT"
+	echo "lab_root: $LAB_ROOT"
+	echo "repo_head: $(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unavailable)"
+	echo "repo_branch: $(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || echo unavailable)"
+	echo
+	echo "[docker context]"
+	if command -v docker >/dev/null 2>&1; then
+		docker context ls 2>/dev/null || true
+	else
+		echo "docker missing"
+	fi
+	echo
+	echo "[orb list]"
+	if command -v orb >/dev/null 2>&1; then
+		orb list 2>/dev/null || true
+	else
+		echo "orb missing"
+	fi
+	echo
+	echo "[relevant containers]"
+	if command -v docker >/dev/null 2>&1; then
+		docker ps --format '{{.Names}}\t{{.Status}}' 2>/dev/null | grep -E 'warp-acp-cli-lab|pipeline-01-n8n|temporal|qdrant|redis' || true
+	else
+		echo "docker missing"
+	fi
+	echo
+	echo "[pipeline status]"
+	if [ -f "$REPO_ROOT/.build/ryota/pipeline_01/status.json" ]; then
+		cat "$REPO_ROOT/.build/ryota/pipeline_01/status.json"
+	else
+		echo "missing: $REPO_ROOT/.build/ryota/pipeline_01/status.json"
+	fi
+	echo
+	echo "[pipeline queue status]"
+	if [ -f "$REPO_ROOT/extensions/ryota-core.vortex-critic/assets/pipeline/data/pipeline_01/commit_queue_status.json" ]; then
+		cat "$REPO_ROOT/extensions/ryota-core.vortex-critic/assets/pipeline/data/pipeline_01/commit_queue_status.json"
+	else
+		echo "missing: queue status"
+	fi
+	echo
+	echo "[warp lab files]"
+	if [ -f "$LAB_ROOT/compose.yaml" ]; then
+		sed -n '1,120p' "$LAB_ROOT/compose.yaml"
+	else
+		echo "missing: $LAB_ROOT/compose.yaml"
+	fi
+	echo
+	echo "[gemini cli]"
+	if [ -n "$GEMINI_BIN" ]; then
+		echo "gemini_bin: $GEMINI_BIN"
+		"$GEMINI_BIN" --version 2>/dev/null || true
+	else
+		echo "gemini missing"
+	fi
+} > "$EVIDENCE_FILE"
+
+PROMPT=$(cat <<'EOF'
+You are evaluating a meaningful multi-layer semantic test for a local AI workflow.
+
+Use the supplied evidence first. If useful, inspect files in the included workspace directories. Stay read-only.
+
+Return concise markdown with these sections exactly:
+- Verdict
+- Runtime Layer
+- Semantic Layer
+- Commit/Pipeline Layer
+- Best Next Test
+
+Rules:
+- Prefer evidence over guesses.
+- Focus on whether this is a meaningful operator-facing test, not just a smoke test.
+- Do not mention secrets or raw environment variables.
+- Keep it concise.
+EOF
+)
+
+GEMINI_STATUS=0
+if [ -n "$GEMINI_BIN" ]; then
+	if ! (
+		cd "$REPO_ROOT"
+		cat "$EVIDENCE_FILE" | "$GEMINI_BIN" \
+			--approval-mode plan \
+			--include-directories "$LAB_ROOT" \
+			--output-format text \
+			-p "$PROMPT"
+	) >"$GEMINI_STDOUT" 2>"$GEMINI_STDERR"; then
+		GEMINI_STATUS=$?
+	fi
+else
+	GEMINI_STATUS=127
+	printf 'Gemini CLI is not installed on this host.\n' >"$GEMINI_STDERR"
+fi
+
+{
+	echo "# OrbStack Gemini Semantic Experiment"
+	echo
+	echo "- timestamp_utc: \`$TIMESTAMP_UTC\`"
+	echo "- hypothesis: $HYPOTHESIS"
+	echo "- repo_root: \`$REPO_ROOT\`"
+	echo "- lab_root: \`$LAB_ROOT\`"
+	echo
+	echo "## Runtime evidence"
+	echo
+	echo '```text'
+	sed -n '1,220p' "$EVIDENCE_FILE"
+	echo '```'
+	echo
+	echo "## Gemini read-only result"
+	echo
+	if [ "$GEMINI_STATUS" -eq 0 ]; then
+		cat "$GEMINI_STDOUT"
+	else
+		echo "- Gemini CLI failed with exit code \`$GEMINI_STATUS\`."
+		echo
+		echo '```text'
+		sed -n '1,160p' "$GEMINI_STDERR"
+		echo '```'
+	fi
+	echo
+	echo "## Commit note"
+	echo
+	echo "- This report is intended to be committed so the commit-driven pipeline can pick up the latest OrbStack experiment."
+} > "$OUTPUT_FILE"
+
+echo "$OUTPUT_FILE"


### PR DESCRIPTION
## Summary
- add a reusable skill for meaningful OrbStack + Gemini CLI semantic experiments
- add a runner that gathers runtime evidence and executes Gemini CLI in read-only mode
- add a checked-in latest experiment report so commit-driven follow-up can inspect the result
